### PR TITLE
simple-console-command

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+// application.php
+
+require __DIR__.'/../vendor/autoload.php';
+
+use Eventjet\GraphqlCodegen\Cli\GenerateCommand;
+use Symfony\Component\Console\Application;
+
+$application = new Application();
+$application->add(new GenerateCommand());
+$application->run();

--- a/src/Cli/GenerateCommand.php
+++ b/src/Cli/GenerateCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Eventjet\GraphqlCodegen\Cli;
+
+use Eventjet\GraphqlCodegen\Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateCommand extends Command
+{
+    protected static $defaultName = 'graphql:generate';
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Generate DTOs from a graphql endpoint.')
+            ->setHelp('This command allows you to generate DTOs from a passed graphql endpoint');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dir = getcwd();
+        $output->writeln(\Safe\sprintf('Generating DTOs from schema.graphql in %s/data', $dir));
+        Generator::run(
+            $dir . '/data/schema.graphql',
+            $dir . '/data/getEvents.graphql',
+            'Generated',
+            $dir . '/data/gql-types/',
+            '7.3'
+        );
+        return Command::SUCCESS;
+
+        // or return this if some error happened during the execution
+        // (it's equivalent to returning int(1))
+        // return Command::FAILURE;
+    }
+}


### PR DESCRIPTION
Apart from tests and fixing bugs with the generator, I would like to have a simple console command to make this code easily useable.

Any suggestions for the console command API?
Should we rely on the query & schema in the file structure, or can we fetch it from a graphql endpoint?
Can I use the eventjet graphql schema as demonstration?